### PR TITLE
Lower PWM frequency on backlight to prevent random reboots

### DIFF
--- a/TFT_LCD/T-Display-Long/V1/Firmware/ESPHome/Halo-v1-Core.yaml
+++ b/TFT_LCD/T-Display-Long/V1/Firmware/ESPHome/Halo-v1-Core.yaml
@@ -157,6 +157,8 @@ output:
   - platform: ledc
     pin: 1
     id: backlight
+    #Datasheet suggests low-frequency PWM. Should prevent stability issues.
+    frequency: 100Hz
   
 display:
   - platform: axs15231


### PR DESCRIPTION
Reduce PWM frequency for backlight to 100Hz to help with stability.