### PR TITLE
Fixing “120MHz is not supported in octal mode”

### DIFF
--- a/TFT_LCD/T-Display-Long/V1/Firmware/ESPHome/Halo-v1-Core.yaml
+++ b/TFT_LCD/T-Display-Long/V1/Firmware/ESPHome/Halo-v1-Core.yaml
@@ -13,6 +13,8 @@ esp32:
   flash_size: 16MB
   framework:
     type: esp-idf
+    advanced:
+      enable_idf_experimental_features: true
 
 esp32_improv:
   authorizer: none

--- a/TFT_LCD/T-Display-Long/V1/Firmware/ESPHome/Halo-v1.yaml
+++ b/TFT_LCD/T-Display-Long/V1/Firmware/ESPHome/Halo-v1.yaml
@@ -5,7 +5,8 @@ esphome:
   platformio_options:
     upload_speed: 921600
     build_unflags: -Werror=all
-    board_build.flash_mode: dio
+    board_build.flash_mode: qio
+    board_build.prsam_type: opi
     board_build.f_flash: 80000000L
     board_build.f_cpu: 240000000L
 


### PR DESCRIPTION
[PR #1](https://github.com/yashmulgaonkar/esphome-components/pull/1) addresses #15, but then we're met with a new error: “120MHz is not supported in octal mode”.

In current ESP-IDF, 120MHz PSRAM is an experimental feature.  Not sure why this worked fine before, but I can confirm that this change was needed after implementing the changes in the PR above.