### PR TITLE
Add MICS4514 NO2 offset configuration

### DIFF
--- a/TFT_LCD/T-Display-Long/V1/Firmware/ESPHome/Halo-v1-Core.yaml
+++ b/TFT_LCD/T-Display-Long/V1/Firmware/ESPHome/Halo-v1-Core.yaml
@@ -1,7 +1,7 @@
 #Define Project
 substitutions:
   name: halo
-  version: "25.9.8.1"
+  version: "25.9.8.2"
   device_description: ${name} - v${version}.
 
 psram:
@@ -307,6 +307,19 @@ number:
     update_interval: never
     step: 0.1
     mode: box
+  - platform: template
+    name: MICS4514 NO2 Offset
+    id: mics4514_no2_offset
+    restore_value: true
+    initial_value: 0
+    min_value: -1.0
+    max_value: 1.0
+    entity_category: "CONFIG"
+    unit_of_measurement: "ppm"
+    optimistic: true
+    update_interval: never
+    step: 0.01
+    mode: box
 
 binary_sensor:
   - platform: status
@@ -385,6 +398,8 @@ sensor:
     nitrogen_dioxide:
       name: Nitrogen Dioxide
       id: "no2"
+      filters:
+        - lambda: return x - id(mics4514_no2_offset).state;
       on_value:
         then:
           - lvgl.label.update:


### PR DESCRIPTION
- Add NO2 offset template number entity (range: ±1.0 ppm, step: 0.01 ppm)
- Apply offset filter to nitrogen_dioxide sensor readings
- Follow same pattern as existing SEN55 temperature/humidity offsets
- Bump version to 25.9.8.2