### PR TITLE
Fix RGB LED rainbow flicker

### DIFF
--- a/TFT_LCD/T-Display-Long/V1/Firmware/ESPHome/Halo-v1-Core.yaml
+++ b/TFT_LCD/T-Display-Long/V1/Firmware/ESPHome/Halo-v1-Core.yaml
@@ -1,7 +1,7 @@
 #Define Project
 substitutions:
   name: halo
-  version: "26.7.24.4"
+  version: "26.7.24.5"
   device_description: ${name} - v${version}.
 
 psram:
@@ -950,10 +950,17 @@ light:
     pin: GPIO47
     num_leds: 12
     chipset: WS2812
+    # Avoid PSRAM/QSPI contention that causes rainbow flicker on T-Display-S3-Long.
+    use_psram: false
+    use_dma: true
+    rmt_symbols: 192
+    max_refresh_rate: 16ms
     restore_mode: RESTORE_AND_OFF
     effects:
       - addressable_rainbow:
           name: Addressable Rainbow
+          speed: 10
+          width: 50
 
   - platform: monochromatic
     output: backlight


### PR DESCRIPTION
## Summary
- Disable PSRAM for esp32_rmt_led_strip and enable DMA to avoid QSPI contention flicker.
- Cap LED refresh at 16ms and slow Addressable Rainbow slightly.